### PR TITLE
mem-ruby: fix CHI Evict race condition

### DIFF
--- a/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
+++ b/src/mem/ruby/protocol/chi/CHI-cache-actions.sm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 ARM Limited
+ * Copyright (c) 2021-2023 ARM Limited
  * All rights reserved
  *
  * The license below extends only to copyright in the software and shall
@@ -923,8 +923,8 @@ action(Initiate_Evict, desc="") {
       tbe.actions.push(Event:WriteBEPipe);
       tbe.actions.push(Event:SendWBData);
     } else {
-      tbe.actions.push(Event:SendCompIResp);
       tbe.actions.push(Event:SendEvict);
+      tbe.actions.push(Event:SendCompIResp);
     }
   } else {
     tbe.actions.push(Event:SendCompIResp);


### PR DESCRIPTION
When an Evict request is received from upstream for a shared line and the line is no longer cached locally (or on any other upstream cache), we need to also send an Evict downstream. In this case we need to wait until our outgoing Evict completes before completing the Evict from upstream in order be able to resolve race conditions with incoming snoops. E.g.: while our outgoing Evict is pending we may receive a snoop requesting data, but we won't be able to complete this snoop if we have already completed all upstream Evicts and we no longer have the line.

Change-Id: I23ac4f0a9c4ddd81e2425376c8d1e1c7fb66d107